### PR TITLE
Fix NullReferenceException when using the control in a DataTemplate

### DIFF
--- a/MultiSelectComboBox/MultiSelectComboBox/Properties/AssemblyInfo.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox/Properties/AssemblyInfo.cs
@@ -52,8 +52,8 @@ using System.Windows.Markup;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.5")]
-[assembly: AssemblyFileVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.6")]
+[assembly: AssemblyFileVersion("1.0.6.0")]
 
 [assembly: XmlnsPrefix("http://schemas.sdl.com/xaml", "sdl")]
 [assembly: XmlnsDefinition("http://schemas.sdl.com/xaml", "Sdl.MultiSelectComboBox.Themes.Generic")]

--- a/MultiSelectComboBox/MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -162,7 +162,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			{
 				_itemsCollectionViewSource = value;
 
-				if (ItemsCollectionViewSource != null)
+				if (ItemsCollectionViewSource != null && ItemsSource != null)
 				{
 					if (EnableGrouping)
 					{


### PR DESCRIPTION
Fix NullReferenceException when using the MultiSelectCombo control in a DataTemplate, and the ViewModel changes. 

To reproduce bug: 
* Step 1: Create ContentControl, bind Content to a vm property (ex: MainViewModel)
* Step 2: Create some data templates
* Step 3: Set the MainViewModel to a type that contains MultiSelectCombo
* Step 4: Set the MainViewModel to another type, NullReferenceException is casued due to ItemsSource being null