### PR TITLE
Changed SelectedItemsProperty modifier to be public

### DIFF
--- a/MultiSelectComboBox/MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -517,7 +517,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 		}
 
-		private static readonly DependencyProperty SelectedItemsProperty =
+		public static readonly DependencyProperty SelectedItemsProperty =
 			DependencyProperty.Register("SelectedItems", typeof(IList), typeof(MultiSelectComboBox),
 				new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedItemsPropertyChangedCallback, SelectedItemsCoerceValueCallback));
 


### PR DESCRIPTION
This property needs to be public, if someone wants to access the binding for the selected items without using Reflection