### PR TITLE
Fix selection in single selection mode

### DIFF
--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -846,7 +846,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
         private void ConfigureSingleSelectionMode(ref Collection<object> itemsRemoved)
         {
-            if (SelectionMode != SelectionModes.Single || SelectedItemsInternal.Count(a => a != null) <= 0)
+            if (SelectionMode != SelectionModes.Single || SelectedItemsInternal.Count(a => a != null) <= 1)
             {
                 return;
             }

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1663,8 +1663,6 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
         public void CloseDropdownMenu(bool clearFilter, bool moveFocus)
         {
-            IsDropDownOpen = false;
-
             if (clearFilter)
             {
                 if (SelectedItemsFilterTextBox != null)
@@ -1686,11 +1684,13 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
                 SetValue(IsEditModePropertyKey, false);
             }
 
-            if (_previousSelectedValue != null && SelectedItems != null && SelectedItems.Count == 0)
+            if (IsDropDownOpen && _previousSelectedValue != null && SelectedItems != null && SelectedItems.Count == 0)
 
             {
                 RestorePreviousSelection();
             }
+
+            IsDropDownOpen = false;
         }
 
 

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -798,8 +798,6 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
             var itemsAdded = new Collection<object>();
             var itemsRemoved = new Collection<object>();
 
-            ConfigureSingleSelectionMode(ref itemsRemoved);
-
             foreach (var comboBoxItem in comboBoxItems)
             {
                 var listBoxItem = GetListViewItem(comboBoxItem);
@@ -828,6 +826,8 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
                 }
             }
 
+            ConfigureSingleSelectionMode(ref itemsRemoved);
+
             var selectedItems = SelectedItemsInternal.Where(a => a != null).ToList();
 
             UpdateSelectedItems(selectedItems);
@@ -851,20 +851,21 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
                 return;
             }
 
+            var lastSelectedItem = SelectedItemsInternal.LastOrDefault(a => a != null);
+
             for (var i = SelectedItemsInternal.Count - 1; i >= 0; i--)
             {
                 var selectedComboBoxItem = SelectedItemsInternal[i];
-                if (selectedComboBoxItem != null)
+                if (selectedComboBoxItem == null || selectedComboBoxItem == lastSelectedItem)
+                    continue;
+                var selectedListBoxItem = GetListViewItem(selectedComboBoxItem);
+                if (selectedListBoxItem != null)
                 {
-                    var selectedListBoxItem = GetListViewItem(selectedComboBoxItem);
-                    if (selectedListBoxItem != null)
-                    {
-                        selectedListBoxItem.IsChecked = false;
-                    }
-
-                    SelectedItemsInternal.RemoveAt(i);
-                    itemsRemoved.Add(selectedComboBoxItem);
+                    selectedListBoxItem.IsChecked = false;
                 }
+
+                SelectedItemsInternal.RemoveAt(i);
+                itemsRemoved.Add(selectedComboBoxItem);
             }
         }
 


### PR DESCRIPTION
Hi,
When I have some selected items and active single select mode then selection is cleaned up after control is loaded.
It looks that it's because ConfigureSingleSelectionMode method.
Control should clean up selection if there is single select and *more than one* item selected.
I tested it on my code and now everything is working.
