### PR TITLE
ItemSource not updated on bound property changed - Bug fix

### DIFF
--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Sdl.MultiSelectComboBox.csproj
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Sdl.MultiSelectComboBox.csproj
@@ -12,6 +12,10 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -575,8 +575,9 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
                 Source = control.ItemsSource
             };
 
-            if (dependencyPropertyChangedEventArgs.NewValue is IList newItems && newItems.Count > 0)
+            if (dependencyPropertyChangedEventArgs.NewValue is IList newItems)
             {
+                control.DropdownListBox.ItemsSource = newItems;
                 control.UpdateSelectedItemsContainer(newItems);
             }
 


### PR DESCRIPTION
When ItemSource was bound to a property that changed, the ItemSource didn't get updated from the bound property, hence showing old/wrong data.